### PR TITLE
c: remove unused variable

### DIFF
--- a/c/mptcphello.c
+++ b/c/mptcphello.c
@@ -12,27 +12,19 @@
 #endif
 
 
-
-
-bool use_mptcp = true;
-
 int main(int argc, char **argv) {
-  
   int s;
 
-  
-  if (use_mptcp) {
-    s = socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP);
+  s = socket(AF_INET, SOCK_STREAM, IPPROTO_MPTCP);
+  if (s == -1) {
+    fprintf(stderr, "Could not create MPTCP socket, falling back to TCP \n");
+
+    s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (s == -1) {
-      use_mptcp = false;
-      fprintf(stderr, "Could not create MPTCP socket, falling back to TCP \n");
-      s = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-      if (s ==-1) {
-	fprintf(stderr, "Could not create TCP socket\n");
-	exit(-1);
-      }
+      fprintf(stderr, "Could not create TCP socket\n");
+      exit(-1);
     }
-    close(s);
-    exit(0);
   }
+  close(s);
+  exit(0);
 }


### PR DESCRIPTION
use_mptcp was set but not used.

We can then simplify the example.