### PR TITLE
python: use socket.IPPROTO_MPTCP if available

### DIFF
--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -1,10 +1,12 @@
 import socket
 
-# On python 3.10 and above, IPPROTO_MPTCP is defined, 
-# s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, IPPROTO_MPTCP)
-# Otherwise, you need to define the constant your self
+# On Python 3.10 and above, socket.IPPROTO_MPTCP is defined.
+# If not, we set it manually
+try:
+  mptcp_protocol = socket.IPPROTO_MPTCP
+except AttributeError:
+  mptcp_protocol = 262
 
-mptcp_protocol = 262
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, mptcp_protocol)
 
 s.connect(("test.multipath-tcp.org" , 80))


### PR DESCRIPTION
In the coming months, Python versions older than 3.10 will be less common.

We can show how to use socket.IPPROTO_MPTCP.