### PR TITLE
Update of python example

### DIFF
--- a/perl/mptcp-hello.pl
+++ b/perl/mptcp-hello.pl
@@ -1,13 +1,33 @@
 use Socket qw(PF_INET SOCK_STREAM pack_sockaddr_in inet_aton);
 
-#IPPROTO_MPTCP=262;
-print "\n";
-socket(my $socket, PF_INET, SOCK_STREAM, 262)
+use Net::protoent;
+$p = getprotobyname(shift || 'mptcp') || die "no proto";
+printf "proto for %s is %d, aliases are %s\n",
+   $p->name, $p->proto, "@{$p->aliases}";
+
+use constant IPPROTO_MPTCP => 262;
+
+my $proto;
+if(defined getprotobyname( shift || 'mptcp' )) {
+    $proto = getprotobyname (shift || 'mptcp' );
+}
+else
+    $proto = ('mptcp', "MPTCP", 262);
+}
+    
+
+socket(my $socket, PF_INET, SOCK_STREAM, $proto)
     or die "socket: $!";
 
+
+
+#socket(my $socket, PF_INET, SOCK_STREAM, IPROTO_MPTCP)
+#    or die "socket: $!";
+
 my $port = getservbyname "http", "tcp";
-connect($socket, pack_sockaddr_in($port, inet_aton("ovh")))
+connect($socket, pack_sockaddr_in($port, inet_aton("test.multipath-tcp.org")))
     or die "connect: $!";
 
-print $socket "Hello, world!\n";
+
+print $socket "GET / HTTP/1.0\r\n\r\n";
 print <$socket>;

--- a/python/README.md
+++ b/python/README.md
@@ -1,25 +1,25 @@
 # Using Multipath TCP in python
 
-To use Multipath TCP in python, you need to pass IPPROTO_MPTCP as the third argument of the socket.socket call as in C. On python 3.10+, this is as
+To use Multipath TCP in python, you need to pass ```IPPROTO_MPTCP``` as the third argument of the ```socket.socket``` call as in C. On python 3.10+, this is as
 simple as :
 
+```python
+socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_MPTCP)
 ```
-socket.socket(sockaf, socket.SOCK_STREAM, IPPROTO_MPTCP)
-```
 
-However, if you want your code to be portable and to run on hosts using older Linux kernels or where Multipath TCP is disabled, you need to take some care. Here are some hints that you might find useful :
+However, if you want your code to be portable and to run on hosts using older Linux kernels, kernels where Multipath TCP is disabled or older versions of python, you need to take some care. Here are some hints that you might find useful :
 
-1. Do not simply use IPPROTO_MPTCP, use a try ... except and set a variable to the expected value of IPPROTO_MPTCP like
+1. Do not simply use ```socket.IPPROTO_MPTCP```, use a ```try ... except``` and set a variable to the expected value of ```socket.IPPROTO_MPTCP``` like
 
-  ```
+  ```python
   try:
-	_mptcp_protocol = socket.IPPROTO_MPTCP
+	IPPROTO_MPTCP = socket.IPPROTO_MPTCP
   except AttributeError:
-        _mptcp_protocol = 262
+        IPPROTO_MPTCP = 262
   ```
 
   Although 262 alone would work, using it directly in your make would make it unreadable.
 
-2. Since the Multipath TCP support is a system property, you should only test it once. If your application creates several TCP sockets and you want to add support for Multipath TCP, you should use a function that creates all the sockets that you need. When first called, this function will try to create a Multipath TCP socket. If this socket fails with either ```ENOPROTOOPT 92 Protocol not available``` or ```EPROTONOSUPPORT 93 Protocol not supported```, this means that it runs on a system that does not support Multipath TCP. You should fallback to TCP and return a regular TCP socket and cache this information such you automatically create TCP sockets at the next calls.
+2. Since the Multipath TCP support is a system property, you should only test it once. If your application creates several TCP sockets and you want to add support for Multipath TCP, you should use a function that creates all the sockets that you need. This function tries to create a Multipath TCP socket. If this socket fails with either ```ENOPROTOOPT 92 Protocol not available``` or ```EPROTONOSUPPORT 93 Protocol not supported```, this means that it runs on a system that does not support Multipath TCP. You should fallback to TCP and return a regular TCP socket and cache this information such you automatically create TCP sockets at the next calls.
 
  [simple example](mptcp-hello.py)

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,25 @@
 # Using Multipath TCP in python
 
+To use Multipath TCP in python, you need to pass IPPROTO_MPTCP as the third argument of the socket.socket call as in C. On python 3.10+, this is as
+simple as :
 
-To use Multipath TCP in python, simply pass Multipath TCP's protocol number (262) as the third argument of the socket system call. On python 3.10+, you can even use IPPROTO_MPTCP as the third argument since this constant is defined in python 3.10+.
+```
+socket.socket(sockaf, socket.SOCK_STREAM, IPPROTO_MPTCP)
+```
+
+However, if you want your code to be portable and to run on hosts using older Linux kernels or where Multipath TCP is disabled, you need to take some care. Here are some hints that you might find useful :
+
+1. Do not simply use IPPROTO_MPTCP, use a try ... except and set a variable to the expected value of IPPROTO_MPTCP like
+
+  ```
+  try:
+	_mptcp_protocol = socket.IPPROTO_MPTCP
+  except AttributeError:
+        _mptcp_protocol = 262
+  ```
+
+  Although 262 alone would work, using it directly in your make would make it unreadable.
+
+2. Since the Multipath TCP support is a system property, you should only test it once. If your application creates several TCP sockets and you want to add support for Multipath TCP, you should use a function that creates all the sockets that you need. When first called, this function will try to create a Multipath TCP socket. If this socket fails with either ```ENOPROTOOPT 92 Protocol not available``` or ```EPROTONOSUPPORT 93 Protocol not supported```, this means that it runs on a system that does not support Multipath TCP. You should fallback to TCP and return a regular TCP socket and cache this information such you automatically create TCP sockets at the next calls.
 
  [simple example](mptcp-hello.py)

--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -1,35 +1,36 @@
 import socket
 import errno
 
+# On Python 3.10 and above, socket.IPPROTO_MPTCP is defined.
+# If not, we set it manually
+try:
+  _mptcp_protocol = socket.IPPROTO_MPTCP
+except AttributeError:
+  _mptcp_protocol = 262
+
 # By default, the application wishes to use Multipath TCP for all sockets
 # provided that it is running on a system that supports Multipath TCP
 _use_mptcp = True
-
-
+  
 def create_socket(sockaf):
-  global _use_mptcp  
-  # On Python 3.10 and above, socket.IPPROTO_MPTCP is defined.
-  # If not, we set it manually
-  try:
-    mptcp_protocol = socket.IPPROTO_MPTCP
-  except AttributeError:
-    mptcp_protocol = 262
+  global _use_mptcp
+  global _mptcp_protocol
   # If Multipath TCP is enabled on this system, we create a Multipath TCP
   # socket
   if _use_mptcp :  
     try:
-      return socket.socket(sockaf, socket.SOCK_STREAM, mptcp_protocol)
-    except OSError as e:
+      return socket.socket(sockaf, socket.SOCK_STREAM, _mptcp_protocol)
+    except socket.error as e:
       # Multipath TCP is not supported, we fall back to regular TCP
       # and remember that Multipath TCP is not enabled
       if e.errno == errno.ENOPROTOOPT or e.errno == errno.ENOPROTONOSUPPORT :
         _use_mptcp = False
-      return socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_TCP)
-  else:
-    # We already know that Multipath TCP does not work on this system
-    return socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+  # Multipath TCP does not work or socket failed, we try TCP
+  return socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_TCP)
 
-    
+#
+# Example usage
+#
 s = create_socket(socket.AF_INET)
 s.connect(("test.multipath-tcp.org" , 80))
 

--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -1,14 +1,36 @@
 import socket
+import errno
 
-# On Python 3.10 and above, socket.IPPROTO_MPTCP is defined.
-# If not, we set it manually
-try:
-  mptcp_protocol = socket.IPPROTO_MPTCP
-except AttributeError:
-  mptcp_protocol = 262
+# By default, the application wishes to use Multipath TCP for all sockets
+# provided that it is running on a system that supports Multipath TCP
+_use_mptcp = True
 
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, mptcp_protocol)
 
+def create_socket(sockaf):
+  global _use_mptcp  
+  # On Python 3.10 and above, socket.IPPROTO_MPTCP is defined.
+  # If not, we set it manually
+  try:
+    mptcp_protocol = socket.IPPROTO_MPTCP
+  except AttributeError:
+    mptcp_protocol = 262
+  # If Multipath TCP is enabled on this system, we create a Multipath TCP
+  # socket
+  if _use_mptcp :  
+    try:
+      return socket.socket(sockaf, socket.SOCK_STREAM, mptcp_protocol)
+    except OSError as e:
+      # Multipath TCP is not supported, we fall back to regular TCP
+      # and remember that Multipath TCP is not enabled
+      if e.errno == errno.ENOPROTOOPT or e.errno == errno.ENOPROTONOSUPPORT :
+        _use_mptcp = False
+      return socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+  else:
+    # We already know that Multipath TCP does not work on this system
+    return socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+
+    
+s = create_socket(socket.AF_INET)
 s.connect(("test.multipath-tcp.org" , 80))
 
 # use the socket as you wish

--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -4,9 +4,9 @@ import errno
 # On Python 3.10 and above, socket.IPPROTO_MPTCP is defined.
 # If not, we set it manually
 try:
-  _mptcp_protocol = socket.IPPROTO_MPTCP
+  IPPROTO_MPTCP = socket.IPPROTO_MPTCP
 except AttributeError:
-  _mptcp_protocol = 262
+  IPPROTO_MPTCP = 262
 
 # By default, the application wishes to use Multipath TCP for all sockets
 # provided that it is running on a system that supports Multipath TCP
@@ -14,17 +14,18 @@ _use_mptcp = True
   
 def create_socket(sockaf):
   global _use_mptcp
-  global _mptcp_protocol
+  global IPPROTO_MPTCP
   # If Multipath TCP is enabled on this system, we create a Multipath TCP
   # socket
   if _use_mptcp :  
     try:
-      return socket.socket(sockaf, socket.SOCK_STREAM, _mptcp_protocol)
+      return socket.socket(sockaf, socket.SOCK_STREAM, IPPROTO_MPTCP)
     except socket.error as e:
       # Multipath TCP is not supported, we fall back to regular TCP
       # and remember that Multipath TCP is not enabled
       if e.errno == errno.ENOPROTOOPT or e.errno == errno.ENOPROTONOSUPPORT :
         _use_mptcp = False
+        
   # Multipath TCP does not work or socket failed, we try TCP
   return socket.socket(sockaf, socket.SOCK_STREAM, socket.IPPROTO_TCP)
 


### PR DESCRIPTION
Python example showing how to fallback to TCP on a system where Multipath TCP is not compiled or not enabled