### PR TITLE
python: example: EINVAL is returned on kernels <5.6

### DIFF
--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -23,7 +23,7 @@ def create_socket(sockaf):
     except socket.error as e:
       # Multipath TCP is not supported, we fall back to regular TCP
       # and remember that Multipath TCP is not enabled
-      if e.errno == errno.ENOPROTOOPT or e.errno == errno.ENOPROTONOSUPPORT :
+      if e.errno == errno.ENOPROTOOPT or e.errno == errno.EPROTONOSUPPORT :
         _use_mptcp = False
         
   # Multipath TCP does not work or socket failed, we try TCP

--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -23,7 +23,9 @@ def create_socket(sockaf):
     except socket.error as e:
       # Multipath TCP is not supported, we fall back to regular TCP
       # and remember that Multipath TCP is not enabled
-      if e.errno == errno.ENOPROTOOPT or e.errno == errno.EPROTONOSUPPORT :
+      if e.errno == errno.ENOPROTOOPT or \
+         e.errno == errno.EPROTONOSUPPORT or \
+         e.errno == errno.EINVAL:
         _use_mptcp = False
         
   # Multipath TCP does not work or socket failed, we try TCP


### PR DESCRIPTION
Before 5.6, proto 262 was not accepted and all numbers above 255 returned EINVAL.

(+ fixed a typo)