### PR TITLE
Replace socket.error (deprecated) with OSError

### DIFF
--- a/python/mptcp-hello.py
+++ b/python/mptcp-hello.py
@@ -20,7 +20,7 @@ def create_socket(sockaf):
   if _use_mptcp :  
     try:
       return socket.socket(sockaf, socket.SOCK_STREAM, IPPROTO_MPTCP)
-    except socket.error as e:
+    except OSError as e:
       # Multipath TCP is not supported, we fall back to regular TCP
       # and remember that Multipath TCP is not enabled
       if e.errno == errno.ENOPROTOOPT or e.errno == errno.ENOPROTONOSUPPORT :


### PR DESCRIPTION
socket.error is a deprecated alias for OSError ([source]( https://docs.python.org/3/library/socket.html#socket.error))